### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For prerequisites and detailed build instructions please read the
 [Installation Instructions](https://github.com/EthereumCommonwealth/go-callisto/wiki/Building-Ethereum)
 on the wiki.
 
-Building geth requires both a Go (version 1.7 or later) and a C compiler.
+Building geth requires both a Go (version 1.10 or later) and a C compiler.
 You can install them using your favourite package manager.
 Once the dependencies are installed, run
 


### PR DESCRIPTION
Updates documentation reference to Go version from 1.7 to 1.10 as minimum required to compile geth.